### PR TITLE
Fix typo in helm template character replace

### DIFF
--- a/docs-v2/content/en/docs/deployers/helm.md
+++ b/docs-v2/content/en/docs/deployers/helm.md
@@ -113,12 +113,13 @@ The `setValues` configuration binds a Helm key to the specified value. The `setV
 | `{{.IMAGE_REPO_NO_DOMAIN_<artifact-name>}}` | `example-repo` |
 
 ### Sanitizing the artifact name from invalid go template characters
-The `<artifact-name>` (eg: `{{.IMAGE_FULLY_QUALIFIED_<artifact-name>}}`) when used with `setValueTemplates` cannot have `/`, `-`, or `.` characters.  If you have an artifact name with these characters (eg: `localhost/nginx` or `gcr.io/foo-image/foo`), change them to use `_` in place of these characters in the `setValueTemplates` field
+The `<artifact-name>` (eg: `{{.IMAGE_FULLY_QUALIFIED_<artifact-name>}}`) when used with `setValueTemplates` cannot have `/`, `-`, `.`, or `:` characters.  If you have an artifact name with these characters (eg: `localhost/nginx` or `gcr.io/foo-image/foo`), change them to use `_` in place of these characters in the `setValueTemplates` field
 
 | Artifact name | Sanitized Name |
 | --------------- | --------------- |
 | `localhost/nginx` | `localhost_nginx`|
 | `gcr.io/example-repo/myImage` | `gcr_io_example_repo_myImage` |
+| `gcr.io/example-repo/myImage:1234_container` | `gcr_io_example_repo_myImage_1234_container` |
 
 Example
 ```yaml

--- a/docs-v2/content/en/docs/renderers/helm.md
+++ b/docs-v2/content/en/docs/renderers/helm.md
@@ -113,12 +113,13 @@ The `setValues` configuration binds a Helm key to the specified value. The `setV
 | `{{.IMAGE_REPO_NO_DOMAIN_<artifact-name>}}` | `example-repo` |
 
 ### Sanitizing the artifact name from invalid go template characters
-The `<artifact-name>` (eg: `{{.IMAGE_FULLY_QUALIFIED_<artifact-name>}}`) when used with `setValueTemplates` cannot have `/`, `-`, or `.` characters.  If you have an artifact name with these characters (eg: `localhost/nginx` or `gcr.io/foo-image/foo`), change them to use `_` in place of these characters in the `setValueTemplates` field
+The `<artifact-name>` (eg: `{{.IMAGE_FULLY_QUALIFIED_<artifact-name>}}`) when used with `setValueTemplates` cannot have `/`, `-`, `.`, or `:` characters.  If you have an artifact name with these characters (eg: `localhost/nginx` or `gcr.io/foo-image/foo`), change them to use `_` in place of these characters in the `setValueTemplates` field
 
 | Artifact name | Sanitized Name |
 | --------------- | --------------- |
 | `localhost/nginx` | `localhost_nginx`|
 | `gcr.io/example-repo/myImage` | `gcr_io_example_repo_myImage` |
+| `gcr.io/example-repo/myImage:1234_container` | `gcr_io_example_repo_myImage_1234_container` |
 
 Example
 ```yaml

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -319,7 +319,7 @@ func hasHiddenPrefix(s string) bool {
 func SanitizeHelmTemplateValue(s string) string {
 	// replaces commonly used image name chars that are illegal go template chars
 	// replaces "/", "-", "." and ":" with "_"
-	r := strings.NewReplacer(".", "_", "-", "_", "/", "_", ":", "/")
+	r := strings.NewReplacer(".", "_", "-", "_", "/", "_", ":", "_")
 	return r.Replace(s)
 }
 

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -317,8 +317,10 @@ func hasHiddenPrefix(s string) bool {
 }
 
 func SanitizeHelmTemplateValue(s string) string {
-	// replaces commonly used image name chars that are illegal go template chars -> replaces "/", "-" and "." with "_"
-	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, ".", "_"), "-", "_"), "/", "_")
+	// replaces commonly used image name chars that are illegal go template chars
+	// replaces "/", "-", "." and ":" with "_"
+	r := strings.NewReplacer(".", "_", "-", "_", "/", "_", ":", "/")
+	return r.Replace(s)
 }
 
 func ParseNamespaceFromFlags(flgs []string) string {


### PR DESCRIPTION
Saw you had a simple typo in the character replace. I fixed the character and tested locally and it fixes my original issue.